### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/1-bug-clear-completed.md
+++ b/docs/1-bug-clear-completed.md
@@ -1,4 +1,3 @@
---8<-- "snippets/1-bug-clear-completed.js"
 
 !!! note "The Bug 'Clear completed'"
     Level: Beginner

--- a/docs/1-bug-hunt-via-k8s.md
+++ b/docs/1-bug-hunt-via-k8s.md
@@ -1,4 +1,3 @@
---8<-- "snippets/1-bug-hunt-via-k8s.js"
 
 ## Hunting via the kubernetes road
 

--- a/docs/2-bug-hunt-via-tracing.md
+++ b/docs/2-bug-hunt-via-tracing.md
@@ -1,4 +1,3 @@
---8<-- "snippets/2-bug-hunt-via-tracing.js"
 
 ## Open the Distributed Tracing App
 !!! Tipp "Protip: Open the Tracing App anywhere in Dynatrace"

--- a/docs/2-bug-special-characters.md
+++ b/docs/2-bug-special-characters.md
@@ -1,4 +1,3 @@
---8<-- "snippets/2-bug-special-characters.js"
 
 !!! note "The Bug 'Special characters'"
     Level: Beginner

--- a/docs/3-bug-duplicate-task.md
+++ b/docs/3-bug-duplicate-task.md
@@ -1,4 +1,3 @@
---8<-- "snippets/3-bug-duplicate-task.js"
 
 !!! note "The Bug 'Duplicate task'"
     Level: Intermediate

--- a/docs/3-bug-hunt-via-logs.md
+++ b/docs/3-bug-hunt-via-logs.md
@@ -1,4 +1,3 @@
---8<-- "snippets/3-bug-hunt-via-logs.js"
 
 ## Hunting road - Logs App
 We have seen how easy it is to find the traces via the Distributed Tracing App, now let's try a different approach. Let's find the trace, it's method and codespace via the Logs App. The Dynatrace Platform is context aware, it knows which traces write which logs, from which pod they are coming from and even which user generated the transaction.

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/cleanup.js"
 
 !!! tip "Deleting the codespace from inside the container"
     We like to make your life easier, for convenience there is a function loaded in the shell of the Codespace for deleting the codespace, just type `deleteCodespace`. This will trigger the deletion of the codespace.

--- a/docs/codespaces.md
+++ b/docs/codespaces.md
@@ -1,5 +1,4 @@
 # Codespaces
---8<-- "snippets/codespaces.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/getting-started.js"
 --8<-- "snippets/grail-requirements.md"
 
 ## 1. Dynatrace Tenant Setup

--- a/docs/grail-and-dql.md
+++ b/docs/grail-and-dql.md
@@ -1,4 +1,3 @@
---8<-- "snippets/grail-and-dql.js"
 
 ??? info "WIP Version control"
     This section is under construction

--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -1,4 +1,3 @@
---8<-- "snippets/ide-integration.js"
 
 !!! example "🧑‍💻 IDE Integration"
     We love Developers and the developer's experience, we understand that for better and faster Software development a developer does not leave it's IDE. We support JetBrains and VSCode as one of the most common IDE's out there. [Here you can read more about the extensions](https://docs.dynatrace.com/docs/observe/applications-and-microservices/developer-observability/offering-capabilities/ide-integration).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/index.js"
 --8<-- "snippets/disclaimer.md"
 
 ## Live Debugger Tutorial - Bug Hunting the TODO App

--- a/docs/mask-data.md
+++ b/docs/mask-data.md
@@ -1,4 +1,3 @@
---8<-- "snippets/mask-data.js"
 
 ## Data masking 
 Dynatrace provides you with tools that enable you to meet your data protection and other compliance requirements while still getting value from any data collected by Dynatrace, including the Live Debugger. 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,4 +1,3 @@
---8<-- "snippets/resources.js"
 
 
 ## Get your Dynatrace environment

--- a/docs/snippets/1-bug-clear-completed.js
+++ b/docs/snippets/1-bug-clear-completed.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1st Bug - clear completed"});
-});
-</script>

--- a/docs/snippets/1-bug-hunt-via-k8s.js
+++ b/docs/snippets/1-bug-hunt-via-k8s.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1st Bug - hunt via kubernetes"});
-});
-</script>

--- a/docs/snippets/2-bug-hunt-via-tracing.js
+++ b/docs/snippets/2-bug-hunt-via-tracing.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2nd Bug - hunt via traces"});
-});
-</script>

--- a/docs/snippets/2-bug-special-characters.js
+++ b/docs/snippets/2-bug-special-characters.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2nd Bug - special characters"});
-});
-</script>

--- a/docs/snippets/3-bug-duplicate-task.js
+++ b/docs/snippets/3-bug-duplicate-task.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3rd Bug - duplicate task"});
-});
-</script>

--- a/docs/snippets/3-bug-hunt-via-logs.js
+++ b/docs/snippets/3-bug-hunt-via-logs.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3rd Bug - hunt via logs"});
-});
-</script>

--- a/docs/snippets/cleanup.js
+++ b/docs/snippets/cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "8. Cleanup"});
-});
-</script>

--- a/docs/snippets/codespaces.js
+++ b/docs/snippets/codespaces.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Codespaces"});
-});
-</script>

--- a/docs/snippets/getting-started.js
+++ b/docs/snippets/getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"});
-});
-</script>

--- a/docs/snippets/grail-and-dql.js
+++ b/docs/snippets/grail-and-dql.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "13. Grail and DQL"});
-});
-</script>

--- a/docs/snippets/ide-integration.js
+++ b/docs/snippets/ide-integration.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. IDE Integration"});
-});
-</script>

--- a/docs/snippets/index.js
+++ b/docs/snippets/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"});
-});
-</script>

--- a/docs/snippets/mask-data.js
+++ b/docs/snippets/mask-data.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. Mask sensitive data"});
-});
-</script>

--- a/docs/snippets/resources.js
+++ b/docs/snippets/resources.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "9. Resources"});
-});
-</script>

--- a/docs/snippets/version-control.js
+++ b/docs/snippets/version-control.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. Version control"});
-});
-</script>

--- a/docs/snippets/whats-next.js
+++ b/docs/snippets/whats-next.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "10. What's next?"});
-});
-</script>

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -1,4 +1,3 @@
---8<-- "snippets/version-control.js"
 
 !!! Example "Automate the Version Control integration for all your environments"
     With environment variables it's easy to point each deployed application in every stage and kubernetes cluster to the right vesion control, branch and commit.

--- a/docs/whats-next.md
+++ b/docs/whats-next.md
@@ -1,4 +1,3 @@
---8<-- "snippets/whats-next.js"
 
 --8<-- "snippets/feedback.md"
 


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)